### PR TITLE
Implement background music feature with options

### DIFF
--- a/app/src/main/java/io/github/luposolitario/damaai/GameActivity.kt
+++ b/app/src/main/java/io/github/luposolitario/damaai/GameActivity.kt
@@ -38,6 +38,7 @@ import io.github.luposolitario.damaai.engine.GemmaEngine
 import io.github.luposolitario.damaai.game_logic.Colore
 import io.github.luposolitario.damaai.game_logic.Difficolta
 import io.github.luposolitario.damaai.game_logic.Posizione
+import io.github.luposolitario.damaai.media.MusicManager
 import io.github.luposolitario.damaai.screen.*
 import io.github.luposolitario.damaai.ui.screen.OptionsScreen
 import io.github.luposolitario.damaai.ui.theme.DamaAITheme
@@ -153,6 +154,14 @@ fun GameScreen(
     boardStyle: BoardStyle,
     settingsViewModel: SettingsViewModel // <-- AGGIUNTO VIEWMODEL
 ) {
+    val context = LocalView.current.context
+
+    // --- Leggiamo le impostazioni musicali ---
+    val musicVolume by settingsViewModel.musicVolume.collectAsState()
+    val classicSongId by settingsViewModel.classicSongId.collectAsState()
+    val teamStyleId by settingsViewModel.playerTeamStyleId.collectAsState()
+
+
     var gameState by remember { mutableStateOf(GameState(pieces = emptyList())) }
     var selectedPieceCoords by remember { mutableStateOf<Posizione?>(null) }
     var validMoveDestinations by remember { mutableStateOf<List<Posizione>>(emptyList()) }
@@ -180,7 +189,23 @@ fun GameScreen(
     }
 
     val coroutineScope = rememberCoroutineScope()
-    val context = LocalView.current.context
+
+    fun getTrackIdByName(name: String): Int? {
+        return when (name) {
+            "italy" -> R.raw.anthem_italy
+            "france" -> R.raw.anthem_france
+            "germany" -> R.raw.anthem_germany
+            "spain" -> R.raw.anthem_spain
+            "uk" -> R.raw.anthem_uk
+            "usa" -> R.raw.anthem_usa
+            "classic_1" -> R.raw.classic_1
+            "classic_2" -> R.raw.classic_2
+            "classic_3" -> R.raw.classic_3
+            "classic_4" -> R.raw.classic_4
+            "classic_5" -> R.raw.classic_5
+            else -> null
+        }
+    }
 
     fun generateComment(prompt: String, onResult: (String) -> Unit) {
         aiOpponent ?: return
@@ -240,6 +265,14 @@ fun GameScreen(
         gameState = gameState.copy(pieces = initialPieces, mandatoryCapturePieces = initialMandatory)
         turnoCorrente = damaEngine.getTurnoCorrente()
 
+        // --- Avvia la musica di gioco ---
+        MusicManager.setVolume(musicVolume)
+        val songToPlayId = if (teamStyleId == "default") classicSongId else teamStyleId
+        getTrackIdByName(songToPlayId)?.let { trackId ->
+            MusicManager.play(context, trackId)
+        }
+
+
         if (aiOpponent != null) {
             try {
                 val modelPath = ModelSettingsManager.getDmModelFilePath(context)
@@ -260,6 +293,8 @@ fun GameScreen(
     DisposableEffect(Unit) {
         onDispose {
             coroutineScope.launch { gemmaEngine.unload() }
+            // Stoppiamo la musica quando si esce dalla schermata di gioco
+            MusicManager.stop()
         }
     }
 

--- a/app/src/main/java/io/github/luposolitario/damaai/datastore/SettingsManager.kt
+++ b/app/src/main/java/io/github/luposolitario/damaai/datastore/SettingsManager.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -22,6 +23,10 @@ class SettingsManager(private val context: Context) {
         val BOARD_STYLE_ID = stringPreferencesKey("board_style_id")
         // --- NUOVA CHIAVE PER LA DIFFICOLTÀ ---
         val DIFFICULTY_LEVEL = stringPreferencesKey("difficulty_level")
+
+        // --- NUOVE CHIAVI PER LA MUSICA ---
+        val MUSIC_VOLUME = floatPreferencesKey("music_volume")
+        val CLASSIC_SONG_ID = stringPreferencesKey("classic_song_id")
     }
 
     // --- Gestione Tema Scuro (invariata) ---
@@ -61,6 +66,34 @@ class SettingsManager(private val context: Context) {
     suspend fun setDifficultyLevel(level: String) {
         context.dataStore.edit { preferences ->
             preferences[DIFFICULTY_LEVEL] = level
+        }
+    }
+
+    // --- NUOVO: Flow per leggere il volume della musica ---
+    val musicVolumeFlow: Flow<Float> = context.dataStore.data
+        .map { preferences ->
+            // Se non c'è un valore salvato, usiamo 0.5f come default.
+            preferences[MUSIC_VOLUME] ?: 0.5f
+        }
+
+    // --- NUOVO: Funzione per salvare il volume della musica ---
+    suspend fun setMusicVolume(volume: Float) {
+        context.dataStore.edit { preferences ->
+            preferences[MUSIC_VOLUME] = volume
+        }
+    }
+
+    // --- NUOVO: Flow per leggere la canzone classica selezionata ---
+    val classicSongIdFlow: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            // Se non c'è un valore salvato, usiamo "classic_1" come default.
+            preferences[CLASSIC_SONG_ID] ?: "classic_1"
+        }
+
+    // --- NUOVO: Funzione per salvare la canzone classica selezionata ---
+    suspend fun setClassicSongId(songId: String) {
+        context.dataStore.edit { preferences ->
+            preferences[CLASSIC_SONG_ID] = songId
         }
     }
 }

--- a/app/src/main/java/io/github/luposolitario/damaai/media/MusicManager.kt
+++ b/app/src/main/java/io/github/luposolitario/damaai/media/MusicManager.kt
@@ -1,0 +1,34 @@
+package io.github.luposolitario.damaai.media
+
+import android.content.Context
+import android.media.MediaPlayer
+import androidx.annotation.RawRes
+
+object MusicManager {
+
+    private var mediaPlayer: MediaPlayer? = null
+    private var currentVolume: Float = 0.5f // Default volume
+
+    fun play(context: Context, @RawRes trackId: Int) {
+        // Stop and release any existing player
+        stop()
+
+        // Create a new media player instance
+        mediaPlayer = MediaPlayer.create(context, trackId).apply {
+            isLooping = true // Loop the music
+            setVolume(currentVolume, currentVolume)
+            start()
+        }
+    }
+
+    fun stop() {
+        mediaPlayer?.release()
+        mediaPlayer = null
+    }
+
+    fun setVolume(volume: Float) {
+        currentVolume = volume
+        // Apply volume to the currently playing media player, if it exists
+        mediaPlayer?.setVolume(volume, volume)
+    }
+}

--- a/app/src/main/java/io/github/luposolitario/damaai/ui/screen/OptionsScreen.kt
+++ b/app/src/main/java/io/github/luposolitario/damaai/ui/screen/OptionsScreen.kt
@@ -13,18 +13,25 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import io.github.luposolitario.damaai.R
 import io.github.luposolitario.damaai.data.availableOpponents
 import io.github.luposolitario.damaai.data.availableTeamStyles
+import io.github.luposolitario.damaai.media.MusicManager
 import io.github.luposolitario.damaai.viewmodels.SettingsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -33,15 +40,54 @@ fun OptionsScreen(
     navController: NavController,
     settingsViewModel: SettingsViewModel
 ) {
+    val context = LocalContext.current
     val selectedDifficulty by settingsViewModel.difficultyLevel.collectAsState()
     val selectedTeamStyleId by settingsViewModel.playerTeamStyleId.collectAsState()
+    val musicVolume by settingsViewModel.musicVolume.collectAsState()
+    val selectedClassicSongId by settingsViewModel.classicSongId.collectAsState()
+
+    val classicSongs = remember {
+        listOf(
+            "classic_1" to "Canzone Classica 1",
+            "classic_2" to "Canzone Classica 2",
+            "classic_3" to "Canzone Classica 3",
+            "classic_4" to "Canzone Classica 4",
+            "classic_5" to "Canzone Classica 5"
+        )
+    }
+
+    fun getTrackIdByName(name: String): Int? {
+        return when (name) {
+            "italy" -> R.raw.anthem_italy
+            "france" -> R.raw.anthem_france
+            "germany" -> R.raw.anthem_germany
+            "spain" -> R.raw.anthem_spain
+            "uk" -> R.raw.anthem_uk
+            "usa" -> R.raw.anthem_usa
+            "classic_1" -> R.raw.classic_1
+            "classic_2" -> R.raw.classic_2
+            "classic_3" -> R.raw.classic_3
+            "classic_4" -> R.raw.classic_4
+            "classic_5" -> R.raw.classic_5
+            else -> null
+        }
+    }
+
+    // Stop music when leaving the screen
+    DisposableEffect(Unit) {
+        onDispose {
+            MusicManager.stop()
+        }
+    }
 
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("Opzioni") },
                 navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
+                    IconButton(onClick = {
+                        navController.popBackStack()
+                    }) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Indietro")
                     }
                 }
@@ -55,6 +101,135 @@ fun OptionsScreen(
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
+            // Section for Team Style
+            item {
+                Text(
+                    text = "Scegli lo stile per le tue pedine:",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+            }
+            items(items = availableTeamStyles, key = { it.id }) { style ->
+                val isSelected = style.id == selectedTeamStyleId
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 3.dp,
+                            color = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent,
+                            shape = RoundedCornerShape(12.dp)
+                        )
+                        .background(
+                            MaterialTheme.colorScheme.surfaceVariant,
+                            RoundedCornerShape(12.dp)
+                        )
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable {
+                            settingsViewModel.setPlayerTeamStyle(style.id)
+                            if (style.id != "default") {
+                                getTrackIdByName(style.id)?.let { trackId ->
+                                    MusicManager.play(context, trackId)
+                                }
+                            } else {
+                                // If classic is selected, play the currently selected classic song
+                                getTrackIdByName(selectedClassicSongId)?.let { trackId ->
+                                    MusicManager.play(context, trackId)
+                                }
+                            }
+                        }
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Image(
+                        painter = painterResource(id = style.flagResId),
+                        contentDescription = "Bandiera ${style.nationName}",
+                        modifier = Modifier.size(40.dp).clip(CircleShape)
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Column {
+                        Text(text = style.nationName, style = MaterialTheme.typography.bodyLarge)
+                        val opponent = availableOpponents.find { it.teamStyleId == style.id }
+                        val opponentText = if (opponent != null) {
+                            "Avversario: ${opponent.name}"
+                        } else {
+                            "Modalità Classica"
+                        }
+                        Text(
+                            text = opponentText,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Light
+                        )
+                    }
+                }
+            }
+
+            item { Divider(modifier = Modifier.padding(vertical = 16.dp)) }
+
+            // Section for Music and Sounds
+            item {
+                Text(
+                    "Musica e Suoni",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
+                Text("Volume", style = MaterialTheme.typography.bodyLarge)
+                Slider(
+                    value = musicVolume,
+                    onValueChange = { newVolume ->
+                        settingsViewModel.setMusicVolume(newVolume)
+                        MusicManager.setVolume(newVolume)
+                    },
+                    valueRange = 0f..1f
+                )
+            }
+
+            // Conditional Dropdown for Classic Music
+            if (selectedTeamStyleId == "default") {
+                item {
+                    var isDropdownExpanded by remember { mutableStateOf(false) }
+
+                    ExposedDropdownMenuBox(
+                        expanded = isDropdownExpanded,
+                        onExpandedChange = { isDropdownExpanded = !isDropdownExpanded }
+                    ) {
+                        TextField(
+                            value = classicSongs.find { it.first == selectedClassicSongId }?.second ?: "",
+                            onValueChange = {},
+                            readOnly = true,
+                            label = { Text("Canzone Classica") },
+                            trailingIcon = {
+                                ExposedDropdownMenuDefaults.TrailingIcon(expanded = isDropdownExpanded)
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .menuAnchor()
+                        )
+                        ExposedDropdownMenu(
+                            expanded = isDropdownExpanded,
+                            onDismissRequest = { isDropdownExpanded = false }
+                        ) {
+                            classicSongs.forEach { (id, name) ->
+                                DropdownMenuItem(
+                                    text = { Text(name) },
+                                    onClick = {
+                                        settingsViewModel.setClassicSongId(id)
+                                        isDropdownExpanded = false
+                                        getTrackIdByName(id)?.let { trackId ->
+                                            MusicManager.play(context, trackId)
+                                        }
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+
+            item { Divider(modifier = Modifier.padding(vertical = 16.dp)) }
+
+            // Section for AI Difficulty
             item {
                 Text(
                     "Livello Difficoltà IA",
@@ -85,57 +260,6 @@ fun OptionsScreen(
                         RadioButton(selected = selectedDifficulty == "DIFFICILE", onClick = { settingsViewModel.setDifficultyLevel("DIFFICILE") })
                         Spacer(modifier = Modifier.width(8.dp))
                         Text("Difficile")
-                    }
-                }
-            }
-
-            item { Divider(modifier = Modifier.padding(vertical = 16.dp)) }
-
-            item {
-                Text(
-                    text = "Scegli lo stile per le tue pedine:",
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(bottom = 8.dp)
-                )
-            }
-            items(items = availableTeamStyles, key = { it.id }) { style ->
-                val isSelected = style.id == selectedTeamStyleId
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 3.dp,
-                            color = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent,
-                            shape = RoundedCornerShape(12.dp)
-                        )
-                        .background(
-                            MaterialTheme.colorScheme.surfaceVariant,
-                            RoundedCornerShape(12.dp)
-                        )
-                        .clip(RoundedCornerShape(12.dp))
-                        .clickable { settingsViewModel.setPlayerTeamStyle(style.id) }
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Image(
-                        painter = painterResource(id = style.flagResId),
-                        contentDescription = "Bandiera ${style.nationName}",
-                        modifier = Modifier.size(40.dp).clip(CircleShape)
-                    )
-                    Spacer(modifier = Modifier.width(16.dp))
-                    Column {
-                        Text(text = style.nationName, style = MaterialTheme.typography.bodyLarge)
-                        val opponent = availableOpponents.find { it.teamStyleId == style.id }
-                        val opponentText = if (opponent != null) {
-                            "Avversario: ${opponent.name}"
-                        } else {
-                            "Modalità Classica (umano vs umano)"
-                        }
-                        Text(
-                            text = opponentText,
-                            style = MaterialTheme.typography.bodySmall,
-                            fontWeight = FontWeight.Light
-                        )
                     }
                 }
             }

--- a/app/src/main/java/io/github/luposolitario/damaai/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/luposolitario/damaai/viewmodels/SettingsViewModel.kt
@@ -57,6 +57,36 @@ class SettingsViewModel(
         }
     }
 
+
+    // --- NUOVO: StateFlow per il volume della musica ---
+    val musicVolume: StateFlow<Float> = settingsManager.musicVolumeFlow
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = 0.5f
+        )
+
+    // --- NUOVO: Funzione per salvare il volume della musica ---
+    fun setMusicVolume(volume: Float) {
+        viewModelScope.launch {
+            settingsManager.setMusicVolume(volume)
+        }
+    }
+
+    // --- NUOVO: StateFlow per la canzone classica selezionata ---
+    val classicSongId: StateFlow<String> = settingsManager.classicSongIdFlow
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = "classic_1"
+        )
+
+    // --- NUOVO: Funzione per salvare la canzone classica selezionata ---
+    fun setClassicSongId(songId: String) {
+        viewModelScope.launch {
+            settingsManager.setClassicSongId(songId)
+        }
+    }
 }
 
 

--- a/app/src/main/res/raw/anthem_france.ogg
+++ b/app/src/main/res/raw/anthem_france.ogg
@@ -1,0 +1,1 @@
+placeholder

--- a/app/src/main/res/raw/anthem_germany.ogg
+++ b/app/src/main/res/raw/anthem_germany.ogg
@@ -1,0 +1,1 @@
+placeholder

--- a/app/src/main/res/raw/anthem_italy.ogg
+++ b/app/src/main/res/raw/anthem_italy.ogg
@@ -1,0 +1,1 @@
+placeholder

--- a/app/src/main/res/raw/anthem_spain.ogg
+++ b/app/src/main/res/raw/anthem_spain.ogg
@@ -1,0 +1,1 @@
+placeholder

--- a/app/src/main/res/raw/anthem_uk.ogg
+++ b/app/src/main/res/raw/anthem_uk.ogg
@@ -1,0 +1,1 @@
+placeholder

--- a/app/src/main/res/raw/anthem_usa.ogg
+++ b/app/src/main/res/raw/anthem_usa.ogg
@@ -1,0 +1,1 @@
+placeholder

--- a/app/src/main/res/raw/classic_1.ogg
+++ b/app/src/main/res/raw/classic_1.ogg
@@ -1,0 +1,1 @@
+placeholder

--- a/app/src/main/res/raw/classic_2.ogg
+++ b/app/src/main/res/raw/classic_2.ogg
@@ -1,0 +1,1 @@
+placeholder

--- a/app/src/main/res/raw/classic_3.ogg
+++ b/app/src/main/res/raw/classic_3.ogg
@@ -1,0 +1,1 @@
+placeholder

--- a/app/src/main/res/raw/classic_4.ogg
+++ b/app/src/main/res/raw/classic_4.ogg
@@ -1,0 +1,1 @@
+placeholder

--- a/app/src/main/res/raw/classic_5.ogg
+++ b/app/src/main/res/raw/classic_5.ogg
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
This change introduces a background music system controlled via a new "Music and Sounds" section in the Options screen.

Key features:
- A volume slider allows you to control the music volume. The setting is persisted across app sessions.
- When a flag piece style is selected, the corresponding national anthem is played.
- When the "Classic" piece style is selected, a dropdown menu appears, allowing you to choose from one of five classic songs.
- The selected music (anthem or classic) automatically plays at the start of a new game.
- Music can be previewed directly from the Options screen.
- I created a singleton `MusicManager` to handle all audio playback, ensuring proper resource management.
- All settings are saved using Android's DataStore.
- I've added placeholder .ogg files for all required tracks.